### PR TITLE
Fix problem with an empty `paths` array

### DIFF
--- a/lib/guard/eslint/runner.rb
+++ b/lib/guard/eslint/runner.rb
@@ -15,7 +15,7 @@ module Guard
       attr_reader :options
 
       def run(paths)
-        paths = options[:default_paths] unless paths
+        paths = options[:default_paths] unless paths&.any?
 
         passed = run_for_check(paths)
         case options[:notification]


### PR DESCRIPTION
Instantiating the runner with an empty `paths` array causes eslint to print usage information and exit, which is not what we want here.